### PR TITLE
Fixed battery function

### DIFF
--- a/scripts/.scripts/panel
+++ b/scripts/.scripts/panel
@@ -165,7 +165,7 @@ cal(){
 
 # Battery
 battery(){
-    if [ -f $POWERSUPPLY ]; then
+    if [ -d $POWERSUPPLY ]; then
         local batt_icon=""
         local batt_level=$(acpi -b | grep -o '[[:digit:]]\+%' | sed 's/%//')
         if [[ $(cat $POWERSUPPLY/online) != 1 ]]; then


### PR DESCRIPTION
`POWERSUPPLY` ( `/sys/class/power_supply/AC0` ) is a directory, not a file. So we need `-d` flag not `-f`.
